### PR TITLE
docs: reschedule roadmap and lock scope to single-user local TUI

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Current Version:** 0.11.0
 **Status:** Active Development - Core Architecture Complete
-**Last Updated:** January 25, 2026
+**Last Updated:** July 4, 2026
 
 ## Overview
 
@@ -60,26 +60,25 @@ AI Signal is a working application with core curation features and a clean archi
 
 **Why RSS First:** Reduces content fetching costs by 50-80% and improves performance 10-100×, enabling affordable AI features downstream.
 
-### Phase 2: Core UX Improvements (Q1 2026)
+### Phase 2: Core UX Improvements (Q3 2026)
 
-- [ ] **Resource Notes** - Add personal notes and annotations to saved items
-- [ ] **Statistics Dashboard** - Which sources and categories are most valuable?
+- [ ] **Resource Notes** ([#11](https://github.com/guglielmo/ai-signal/issues/11)) - Add personal notes and annotations to saved items — Jul 13-20, 2026
+- [ ] **Statistics Dashboard** ([#4](https://github.com/guglielmo/ai-signal/issues/4)) - Which sources and categories are most valuable? — Aug 3-10, 2026
 - [ ] **Better Sorting** - Enhanced sort options (recency, category, source)
 - [ ] **UI Polish** - Refinements based on real usage patterns
 
-### Phase 3: AI Intelligence Features (Q2 2026)
+### Phase 3: AI Intelligence Features (Q3-Q4 2026)
 
-- [ ] **Content Summarization** - Generate summaries and key takeaways
-- [ ] **Wisdom Extraction** - Pull out actionable insights from content
-- [ ] **Multi-LLM Support** - Choose from OpenAI, Claude, Gemini, or local models
-- [ ] **Batch Optimization** - Efficient grouping of source analysis
+- [ ] **Multi-LLM Support** ([#12](https://github.com/guglielmo/ai-signal/issues/12)) - Choose from OpenAI, Claude, Gemini, or local models — Aug 24-31, 2026
+- [ ] **Content Summarization / Wisdom Extraction** ([#7](https://github.com/guglielmo/ai-signal/issues/7)) - Generate summaries and pull out actionable insights — Sep 7-14, 2026
+- [ ] **Batch Optimization** ([#3](https://github.com/guglielmo/ai-signal/issues/3)) - Efficient grouping of source analysis — Sep 28-Oct 5, 2026
 
-### Phase 4: Learning & Personalization (Q3 2026+)
+### Phase 4: Learning & Personalization (Q4 2026)
 
-- [ ] **Feedback Loop** - Learn from your reading patterns and choices
+- [ ] **YouTube Videos** ([#5](https://github.com/guglielmo/ai-signal/issues/5)) - Transcribe and analyze video content — Oct 19-26, 2026
+- [ ] **Feedback Loop** ([#6](https://github.com/guglielmo/ai-signal/issues/6)) - Learn from your reading patterns and choices — Nov 9-30, 2026
 - [ ] **Category Suggestions** - Discover new interests based on behavior
 - [ ] **Source Recommendations** - Find relevant blogs and feeds
-- [ ] **YouTube Videos** - Transcribe and analyze video content
 - [ ] **Content Archiving** - Read/unread status, filtering, search
 
 ### Future Considerations


### PR DESCRIPTION
## Summary

Two related documentation changes:

### 1. Reschedule Phase 2-4 roadmap into Q3-Q4 2026
- RSS integration (Phase 1) is nearly complete, so Phases 2-4 of the roadmap are remodulated to fit within Q3-Q4 2026 instead of the original Q1-Q3 2026 window
- Updates `STATUS.md` phase headers, per-item target dates/links, and the "Last Updated" date
- Updates the start/end date estimates on the corresponding GitHub issues (#3, #4, #5, #6, #7, #11, #12), preserving existing dependency ordering (e.g. #12 before #7, #11/#4 before #6)

### 2. Lock scope to single-user, local-only TUI; strip multi-user/web content
- AI Signal will remain a single-user, local-only prototype permanently — no multi-user mode, no hosted/web version
- `README.md`, `STATUS.md`, `VISION.md`, `CLAUDE.md`: removed/reframed every mention that hinted at a multi-user or web/API evolution; added explicit scope statements and a "Non-Goals" / "Out of Scope" callout
- `docs/architecture/event-bus.md`: corrected inaccurate claims about `user_context` providing multi-tenant isolation — it doesn't; documented as unused plumbing instead
- `pyproject.toml`: removed a misleading PyPI classifier (`Internet :: WWW/HTTP :: Dynamic Content`) left over from earlier multi-UI aspirations
- Closed issues #27 (multi-user data model prep) and #28 (FastAPI skeleton) as `not_planned`, with a comment pointing to a standalone handoff document for a possible separate future project that would reuse some of AI Signal's core abstractions

## New schedule

| Phase | Window | Issue | Dates |
|---|---|---|---|
| 2 – Core UX | Q3 2026 | #11 Notes | Jul 13-20, 2026 |
| | | #4 Statistics | Aug 3-10, 2026 |
| 3 – AI Intelligence | Q3-Q4 2026 | #12 LLM engine config | Aug 24-31, 2026 |
| | | #7 Summarize/Wisdom | Sep 7-14, 2026 |
| | | #3 Request optimization | Sep 28-Oct 5, 2026 |
| 4 – Learning & Personalization | Q4 2026 | #5 YouTube | Oct 19-26, 2026 |
| | | #6 Feedback loop | Nov 9-30, 2026 |

## Test plan
- [x] Docs-only change; no code affected
- [x] Cross-checked issue dependency ordering is preserved after the shift
- [x] Verified no remaining multi-user/web references in README/STATUS/VISION/CLAUDE beyond the intentionally-archived historical docs under `docs/archive/`
